### PR TITLE
Bump build image to VS2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 3.0.0.{build}
 
 configuration: Release
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
Looks like the AppVeyor build environment only has support for .NET Core 3.0 on the Visual Studio 2019 image.