### PR TITLE
Some more build fixes

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -41,19 +41,6 @@ task :version do
 	:informational_version => asm_version
 
   }
-
-  puts "Writing src/CommonAssemblyInfo.cs..."
-	File.open('src/CommonAssemblyInfo.cs', 'w') do |file|
-		file.write "using System.Reflection;\n"
-		file.write "using System.Runtime.InteropServices;\n"
-		file.write "[assembly: AssemblyDescription(\"#{options[:description]}\")]\n"
-		file.write "[assembly: AssemblyProduct(\"#{options[:product_name]}\")]\n"
-		file.write "[assembly: AssemblyCopyright(\"#{options[:copyright]}\")]\n"
-		file.write "[assembly: AssemblyTrademark(\"#{options[:trademark]}\")]\n"
-		file.write "[assembly: AssemblyVersion(\"#{options[:version]}\")]\n"
-		file.write "[assembly: AssemblyFileVersion(\"#{options[:file_version]}\")]\n"
-		file.write "[assembly: AssemblyInformationalVersion(\"#{options[:informational_version]}\")]\n"
-	end
 end
 
 

--- a/src/Alba/Alba.csproj
+++ b/src/Alba/Alba.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Supercharged integration testing for ASP.Net Core HTTP endpoints</Description>
@@ -23,6 +23,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/Alba/Alba.csproj
+++ b/src/Alba/Alba.csproj
@@ -4,7 +4,7 @@
     <Description>Supercharged integration testing for ASP.Net Core HTTP endpoints</Description>
     <AssemblyTitle>Alba</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Alba</AssemblyName>
     <PackageId>Alba</PackageId>
@@ -25,18 +25,15 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
   </ItemGroup>
-    
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.*" />
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+      <PackageReference Include="Microsoft.AspNetCore.All" />
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
   </ItemGroup>
 
-
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+      <PackageReference Include="Microsoft.AspNetCore.All" />
+      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.*" />
+  </ItemGroup>
 
 </Project>

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,9 +1,0 @@
-using System.Reflection;
-using System.Runtime.InteropServices;
-[assembly: AssemblyDescription("Grab bag of generic utilities and extension methods for .Net development")]
-[assembly: AssemblyProduct("Baseline")]
-[assembly: AssemblyCopyright("Copyright 2015 Jeremy D. Miller et al. All rights reserved.")]
-[assembly: AssemblyTrademark("3dc7ef9033205917731913e51b62a3dbe0caa8f1")]
-[assembly: AssemblyVersion("0.5.0.51405")]
-[assembly: AssemblyFileVersion("0.5.0.51405")]
-[assembly: AssemblyInformationalVersion("0.5.0.51405")]


### PR DESCRIPTION
I've made a couple of more changes to how the build works:
- Alba project now explicitly targets netcoreapp2.1;netcoreapp2.2;netcoreapp3.0 so no longer netstandard2.0
- The project uses the Microsoft.NET.Sdk SDK, instead of the Microsoft.NET.Sdk**.Web**. SDK, which makes it packable again. I don't think it's necessary to target the Web SDK since we're not actually producing a Web application but rather a library.
- Removed the CommonAssemblyInfo.cs and related stuff since I understood from @jeremydmiller that it wasn't necessary anymore