### PR TITLE
Fix a packaging issue

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -58,7 +58,7 @@ end
 
 desc "Pack up the nupkg file"
 task :pack => [:compile] do
-	sh "dotnet pack src/Alba/Alba.csproj -o ./../../artifacts --configuration Release"
+	sh "dotnet pack src/Alba/Alba.csproj -o ./artifacts --configuration Release"
 end
 
 # TODO -- redo these tasks


### PR DESCRIPTION
Looks like dotnet pack changed to use the output path relative from the directory where the command is run, instead of the path where the project file is located.